### PR TITLE
Circuit breaker - test 1 and 2: change Docker image to correct issue …

### DIFF
--- a/src/documentation/modules/istio/pages/07_circuit-breaker.adoc
+++ b/src/documentation/modules/istio/pages/07_circuit-breaker.adoc
@@ -55,7 +55,7 @@ Let's perform a load test in our system with `siege`. We'll have 20 clients send
 
 [source,bash]
 ----
-docker run lonelyplanet/siege siege -r 2 -c 20 -v $CUSTOMER_URL
+docker run --rm funkygibbon/siege siege -r 2 -c 20 -v $CUSTOMER_URL
 ----
 
 You should see an output similar to this:
@@ -101,7 +101,7 @@ Now let's see what is the behavior of the system running `siege` again:
 
 [source,bash]
 ----
-docker run lonelyplanet/siege siege -r 2 -c 20 -v $CUSTOMER_URL
+docker run --rm funkygibbon/siege siege -r 2 -c 20 -v $CUSTOMER_URL
 ----
 
 image:k8s-istio-7.circuit-breaker.png[]


### PR DESCRIPTION
…related to Siege version

Change Docker image from lonelyplanet/siege, running a Siege v2.7.0, to funkygibbon/siege, running a v4.0.4.

Old version use resulted in a path issue ("[alert] unable to open file: /usr/etc/urls.txt: No such file or directory"), as explained here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=610420

New Docker command run: "docker run --rm funkygibbon/siege siege -r 2 -c 20 -v $CUSTOMER_URL"